### PR TITLE
Compare and diff all URLs in the HAR.

### DIFF
--- a/js/compare-har.js
+++ b/js/compare-har.js
@@ -1,4 +1,4 @@
-/* exported getLastTiming getAllDomains*/
+/* exported getLastTiming getAllDomains getURLsDiff*/
 
 /**
  * Helper functions to get things out of the HAR
@@ -35,6 +35,32 @@ function getLastTiming(har, run) {
   });
 
   return doneTime;
+}
+
+function getURLsDiff(har1, run1, har2, run2) {
+  const urls1 = getURLs(har1, run1);
+  const urls2 = getURLs(har2, run2);
+  let diffHar1 = urls1.filter(x => !urls2.includes(x));
+  let diffHar2 = urls2.filter(x => !urls1.includes(x));
+  return { diff1: diffHar1, diff2: diffHar2 };
+}
+
+function getURLs(har, run) {
+  const harEntries = har.log.entries;
+  const pageId = har.log.pages[run].id;
+  harEntries.filter(entry => {
+    // filter inline data
+    if (
+      entry.request.url.indexOf('data:') === 0 ||
+      entry.request.url.indexOf('javascript:') === 0
+    ) {
+      return false;
+    }
+    return entry.pageref === pageId;
+  });
+  const urls = [];
+  harEntries.filter(entry => urls.push(entry.request.url));
+  return urls;
 }
 
 function getAllDomains(firstPage, secondPage) {

--- a/js/compare-ux.js
+++ b/js/compare-ux.js
@@ -1,4 +1,4 @@
-/* global Chartist, Template7, getLastTiming, perfCascade, createUpload, getAllDomains */
+/* global Chartist, Template7, getLastTiming, perfCascade, createUpload, getAllDomains getURLsDiff*/
 /* exported showUpload, formatDate, generate, toggleRow, regenerate*/
 
 // Hide the upload functionality
@@ -341,6 +341,21 @@ function generate(config1, config2) {
     },
     'domainsContent'
   );
+
+  const urlDiff = getURLsDiff(
+    config1.har,
+    config1.run,
+    config2.har,
+    config2.run
+  );
+
+  // We only log this information for now
+  /* eslint-disable no-console */
+  console.log('Requests in HAR1 but not in HAR2:');
+  console.log(urlDiff.diff1);
+  console.log('Requests in HAR2 but not in HAR1:');
+  console.log(urlDiff.diff2);
+  /* eslint-enable no-console */
 
   createUpload('har1upload');
   createUpload('har2upload');


### PR DESCRIPTION
This can potentially make it easier to find difference between HARs. It takes all the URLs from one run in one HAR and compare it to the one other run in another HAR. Right now we only log it to the console but it would be sweat if we could use it in the output in a smart way:

<img width="1251" alt="screen shot 2018-04-23 at 3 52 31 pm" src="https://user-images.githubusercontent.com/540757/39130953-a1e42f24-470e-11e8-91d4-3b93e6dc1da5.png">


