### PR TITLE
Update the browsersync file to regenerate SW on development change

### DIFF
--- a/gulp-tasks/browser-sync.js
+++ b/gulp-tasks/browser-sync.js
@@ -8,6 +8,7 @@ const changed = require('gulp-changed');
 
 // import local sass module for watch task
 const sass = require('./sass');
+const generateSW = require('./generate-service-worker');
 const gulpPaths = require('../gulp-paths');
 
 
@@ -65,11 +66,11 @@ function serveTask(){
   });
 
   // If sass changes, inject into the page
-  gulp.watch(`${gulpPaths.paths.src.sass}*.scss`, sass);
+  gulp.watch(`${gulpPaths.paths.src.sass}**/*.scss`, gulp.series(generateSW, sass));
   // if any below file changes will browsersync will reload the page
-  gulp.watch(`${gulpPaths.paths.dist.js}**/*`).on('change', reload);
-  gulp.watch(`${gulpPaths.paths.dist.img}**/*`).on('change', reload);
-  gulp.watch(`${gulpPaths.paths.dist.build}*.html`).on('change', reload);
+  gulp.watch(`${gulpPaths.paths.dist.js}**/*`).on('change', gulp.series(generateSW, reload));
+  gulp.watch(`${gulpPaths.paths.dist.img}**/*`).on('change', gulp.series(generateSW, reload));
+  gulp.watch(`${gulpPaths.paths.dist.build}*.html`).on('change', gulp.series(generateSW, reload));
 }
 
 // watch files and serve run in parallel

--- a/gulp-tasks/generate-service-worker.js
+++ b/gulp-tasks/generate-service-worker.js
@@ -37,3 +37,6 @@ function generateTask() {
 }
 
 gulp.task('generate-sw', generateTask);
+
+// expose the module so it can be used in browsersync watch
+module.exports = generateTask;


### PR DESCRIPTION
This is a fix for [issue 60](https://github.com/sitespeedio/compare/issues/60). On a development change the service worker task will be triggered and a new SHA for the file generated. This will force the service worker to update the cached version.