### PR TITLE
Revert "Display 3 decimals instead of 1 for CPU metrics"

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,33 +245,33 @@
             <tr>
               <td class="tabletext">CPU Painting:
               </td>
-              <td>{{cpuCategories1.Painting.toFixed(3)}}
+              <td>{{cpuCategories1.Painting.toFixed(1)}}
               </td>
-              <td>{{cpuCategories2.Painting.toFixed(3)}}
+              <td>{{cpuCategories2.Painting.toFixed(1)}}
               </td>
             </tr>
             <tr>
               <td class="tabletext">CPU Loading:
               </td>
-              <td>{{cpuCategories1.Loading.toFixed(3)}}
+              <td>{{cpuCategories1.Loading.toFixed(1)}}
               </td>
-              <td>{{cpuCategories2.Loading.toFixed(3)}}
+              <td>{{cpuCategories2.Loading.toFixed(1)}}
               </td>
             </tr>
             <tr>
               <td class="tabletext">CPU Rendering:
               </td>
-              <td>{{cpuCategories1.Rendering.toFixed(3)}}
+              <td>{{cpuCategories1.Rendering.toFixed(1)}}
               </td>
-              <td>{{cpuCategories2.Rendering.toFixed(3)}}
+              <td>{{cpuCategories2.Rendering.toFixed(1)}}
               </td>
             </tr>
             <tr>
               <td class="tabletext">CPU Scripting:
               </td>
-              <td>{{cpuCategories1.Scripting.toFixed(3)}}
+              <td>{{cpuCategories1.Scripting.toFixed(1)}}
               </td>
-              <td>{{cpuCategories2.Scripting.toFixed(3)}}
+              <td>{{cpuCategories2.Scripting.toFixed(1)}}
               </td>
             </tr>
             <tr>
@@ -283,14 +283,14 @@
               <td>
                 <ul>
                   {{#each cpuEvents1}}
-                      <li>{{name}} : {{value.toFixed(3)}}</li>
+                      <li>{{name}} : {{value.toFixed(1)}}</li>
                   {{/each}}
                 </ul>
               </td>
               <td>
                 <ul>
                   {{#each cpuEvents2}}
-                      <li>{{name}} : {{value.toFixed(3)}}</li>
+                      <li>{{name}} : {{value.toFixed(1)}}</li>
                   {{/each}}
                 </ul>
               </td>


### PR DESCRIPTION
Reverts sitespeedio/compare#66 since it didn't give any extra info.