### PR TITLE
Update to Workbox 4.0.0 for SW generation

### DIFF
--- a/gulp-tasks/generate-service-worker.js
+++ b/gulp-tasks/generate-service-worker.js
@@ -8,19 +8,43 @@ const gulpPaths = require('../gulp-paths');
 
 const swSetup = {
   // set cache name prefix
-  cacheId: 'sitespeed.io-compare-',
+  cacheId: 'sitespeed.io-compare-html-',
   // only allow caching of files under 1MB
   maximumFileSizeToCacheInBytes: 1 * 1024 * 1024,
   // use the a local copy of workbox (no the CDN)
   importWorkboxFrom: 'local',
   // what directory / files to precache
   globDirectory: gulpPaths.paths.dist.build,
-  globPatterns: ['**\/*.{html,js,css,png,jpg,jpeg,ico}'],
+  globPatterns: ['**\/*.html'],
   swDest: `${gulpPaths.paths.dist.build}service-worker.js`,
   // claim any browser tabs that are running immediately
   clientsClaim: true,
   // skip the wait and init immediately
-  skipWaiting: true
+  skipWaiting: true,
+  // remove outdated caches from WorkBox 3.x.x
+  cleanupOutdatedCaches: true,
+  // define custom caching routes for more flexibility
+  runtimeCaching: [{
+    urlPattern: new RegExp('.*.(?:css|js)'),
+    // using cache first strategy since files are revisioned
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'sitespeed.io-compare-application-cache-',
+      expiration: {
+        // assets cached for 30 days ensuring older revisions clear out after this time
+        maxAgeSeconds: 30 * 24 * 60 * 60
+      }
+    }
+  },
+  {
+    urlPattern: new RegExp('.*.(?:png|jpg|jpeg|ico)'),
+    // StaleWhileRevalidate used for minor assets, cache used first then updated later if required
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'sitespeed.io-compare-image-cache-'
+    }
+  }
+]
 };
 
 function generateTask() {

--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
       {{else}}
       <p class="small">Using <b>{{p1.firstPartyRegEx}}</b> as <i>--firstParty</i> parameter for {{config.har1.label}} and <b>{{p2.firstPartyRegEx}}</b> for {{config.har2.label}}.</p>
     {{/js_compare}}
-    
+
     <div id="comment-firstParty" class="comment"></div>
     <table>
       <thead>
@@ -330,10 +330,10 @@
           <td>{{this.requests}}</td>
           <td>{{get @root.p2.firstParty.contentTypes @key 'requests'}}</td>
         </tr>
-        {{/each}}         
+        {{/each}}
         <tr>
           <td class="tabletext">First party transfer size <button onclick="toggleRow(this, 'firstPartyTransferSize', this.childNodes[0]);" class="submit submit-smaller"><i class="arrow right"></i></button></td>
-          <td>{{js "formatBytes(this.p1.firstParty.transferSize)"}} 
+          <td>{{js "formatBytes(this.p1.firstParty.transferSize)"}}
         ({{js "this.p1.firstParty.transferSize>0?Math.round((this.p1.firstParty.transferSize / this.p1.transferSize)*100):0"}}%)</td>
           <td>{{js "formatBytes(this.p2.firstParty.transferSize)"}} ({{js "this.p2.firstParty.transferSize>0?Math.round((this.p2.firstParty.transferSize / this.p2.transferSize)*100):0"}}%)</td>
         </tr>
@@ -407,7 +407,7 @@
         <a href="#firstPartyHeader">1st vs 3rd party</a> -
       {{/if}}
       {{#js_compare "this.p1.url === this.p2.url"}}
-        <a href="#requestDifffHeader">Request diff</a> - 
+        <a href="#requestDifffHeader">Request diff</a> -
       {{/js_compare}}
       <a href="#domainsHeader">Domains</a>
     </div>
@@ -460,7 +460,7 @@
       <h3 id="requestDifffHeader">Request/response difference (larger than 1 kb)</h3>
       <div id="comment-requestDiff" class="comment">
       </div>
-      {{#js_compare "this.requestDiff.length > 0 "}} 
+      {{#js_compare "this.requestDiff.length > 0 "}}
         <div class="col-1-1">
           <table class="requestDiffTable">
           <thead>
@@ -480,7 +480,7 @@
                     {{#js_compare "this.har1 && this.har2"}}
                       {{#js_compare "this.diff < 0"}}
                         <td class="tabletext green">{{js "formatBytes(this.diff)"}}</td>
-                      {{else}} 
+                      {{else}}
                         <td class="tabletext red">+{{js "formatBytes(this.diff)"}}</td>
                       {{/js_compare}}
                     {{else}}
@@ -501,9 +501,9 @@
             {{else}}
               <td class="tabletext red"><b>+{{js "formatBytes(this.total.diff)"}}</b></td>
             {{/js_compare}}
-          </tr>  
+          </tr>
           </tbody>
-          </table> 
+          </table>
           <table>
             <thead>
                 <tr>
@@ -527,7 +527,7 @@
               <tr>
                   <td class="tabletext">Decreased ({{total.decreased}})</td>
                   <td class="green">{{js "formatBytes(this.total.decreasedBytes)"}}</td>
-              </tr>  
+              </tr>
               <tr>
                   <td class="tabletext"><b>Total</b></td>
                   {{#js_compare "this.total.diff < 0"}}
@@ -541,7 +541,7 @@
         </div>
       {{else}}
         <p>There are no difference in size of the requests/responses.</p>
-      {{/js_compare}} 
+      {{/js_compare}}
     {{/if}}
   </script>
 
@@ -750,13 +750,14 @@
         return decodeURIComponent(name[1]);
     }
   </script>
-  <script>
+  <script type="module">
+    import {Workbox} from '/workbox-v4.0.0/workbox-window.prod.mjs';
+
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js');
-      });
+      const wb = new Workbox('/service-worker.js');
+      wb.register();
     }
-</script>
+  </script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
@@ -572,7 +581,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -594,6 +603,14 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "babylon": {
@@ -1513,9 +1530,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
     },
     "core-util-is": {
@@ -3196,7 +3213,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3217,12 +3235,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3237,17 +3257,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3364,7 +3387,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3376,6 +3400,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3390,6 +3415,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3397,12 +3423,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3421,6 +3449,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3501,7 +3530,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3513,6 +3543,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3598,7 +3629,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3634,6 +3666,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3653,6 +3686,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3696,12 +3730,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7930,9 +7966,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
       "dev": true
     },
     "regex-cache": {
@@ -10315,30 +10351,30 @@
       "dev": true
     },
     "workbox-background-sync": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
-      "integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-4.0.0.tgz",
+      "integrity": "sha512-U8hCVqF1m/xaQnRVI4N3eRK9sQwlEH6C5BGORwVs4jBTf1bfo3EDUR2K1qhkWdGgRKBWQfSb2YHVBrxlpt6z8g==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
-    "workbox-broadcast-cache-update": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
-      "integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
+    "workbox-broadcast-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-4.0.0.tgz",
+      "integrity": "sha512-xnnhXdgKU5OLFzc4v6n12O0iX+I4IxEZ2zV9xEQiUXCRWh/8gEcyXFdPK7Tayj5C3NwN1wrQgpSCJ5FBwVr63Q==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-build": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
-      "integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-4.0.0.tgz",
+      "integrity": "sha512-xWz4I1ZGVWQpgBq+Q8xsFF0fdHkVM+8N+uoPm+XCujmYlhxry+f87c49Yp/DcV1mHr6YIqcA5lnZu0ix77iacg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.0.0",
         "common-tags": "^1.4.0",
         "fs-extra": "^4.0.2",
         "glob": "^7.1.2",
@@ -10347,19 +10383,20 @@
         "pretty-bytes": "^4.0.2",
         "stringify-object": "^3.2.2",
         "strip-comments": "^1.0.2",
-        "workbox-background-sync": "^3.6.3",
-        "workbox-broadcast-cache-update": "^3.6.3",
-        "workbox-cache-expiration": "^3.6.3",
-        "workbox-cacheable-response": "^3.6.3",
-        "workbox-core": "^3.6.3",
-        "workbox-google-analytics": "^3.6.3",
-        "workbox-navigation-preload": "^3.6.3",
-        "workbox-precaching": "^3.6.3",
-        "workbox-range-requests": "^3.6.3",
-        "workbox-routing": "^3.6.3",
-        "workbox-strategies": "^3.6.3",
-        "workbox-streams": "^3.6.3",
-        "workbox-sw": "^3.6.3"
+        "workbox-background-sync": "^4.0.0",
+        "workbox-broadcast-update": "^4.0.0",
+        "workbox-cacheable-response": "^4.0.0",
+        "workbox-core": "^4.0.0",
+        "workbox-expiration": "^4.0.0",
+        "workbox-google-analytics": "^4.0.0",
+        "workbox-navigation-preload": "^4.0.0",
+        "workbox-precaching": "^4.0.0",
+        "workbox-range-requests": "^4.0.0",
+        "workbox-routing": "^4.0.0",
+        "workbox-strategies": "^4.0.0",
+        "workbox-streams": "^4.0.0",
+        "workbox-sw": "^4.0.0",
+        "workbox-window": "^4.0.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -10403,101 +10440,110 @@
         }
       }
     },
-    "workbox-cache-expiration": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
-      "integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
-      "dev": true,
-      "requires": {
-        "workbox-core": "^3.6.3"
-      }
-    },
     "workbox-cacheable-response": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
-      "integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0.tgz",
+      "integrity": "sha512-cT3b1iotdV5+rYZKnAWvo3D8UAgfuN2HWuf+WuNC1YR0tnGmFAOX8shfEV9DZmnzxDgY8cOcOCK8PSf5uCaGBg==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz",
-      "integrity": "sha512-cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-4.0.0.tgz",
+      "integrity": "sha512-FRoOUuJBl7COTwvGO5FC9k0VyYGv/LkjVqgVwKk9MXQn/Xi+bvGDcqSVF7qfT+sJ6Ffcr/V+dVMpoZAE/X5e+g==",
       "dev": true
     },
-    "workbox-google-analytics": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
-      "integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
+    "workbox-expiration": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-4.0.0.tgz",
+      "integrity": "sha512-j0h8H8hmSd+Sh9qSlmC1JwViRdxtzbdjuH32qmkYgXDGXwMprV6QU2kQ51J+7Dhm10OdQ64RGfGjbe7bjgzDuw==",
       "dev": true,
       "requires": {
-        "workbox-background-sync": "^3.6.3",
-        "workbox-core": "^3.6.3",
-        "workbox-routing": "^3.6.3",
-        "workbox-strategies": "^3.6.3"
+        "workbox-core": "^4.0.0"
+      }
+    },
+    "workbox-google-analytics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-4.0.0.tgz",
+      "integrity": "sha512-WjZM3frkuCYQUmq8uICzpt+3NnjKhO/GEV+EOqRJgZMfZfmFxMUHbUKi3I/8TXWLigWJbtv/mh4zh0OtFX+vKw==",
+      "dev": true,
+      "requires": {
+        "workbox-background-sync": "^4.0.0",
+        "workbox-core": "^4.0.0",
+        "workbox-routing": "^4.0.0",
+        "workbox-strategies": "^4.0.0"
       }
     },
     "workbox-navigation-preload": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
-      "integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0.tgz",
+      "integrity": "sha512-G2sDCrekZUNFxkBSAcYQHkUbVMJwhkdVFqnCYxmeTiBzOILokVsghmr90CQ4m98gcqc+P4GoMMc+196jN9r+SA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-precaching": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
-      "integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-4.0.0.tgz",
+      "integrity": "sha512-juI7N+Rj2/CWU3FXedcDLdjzqvRMpkaQsdsfAxBii5017bivw3Dve/kf4qXePccD2hJ973vKY2F7EJRUos8JvA==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-range-requests": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
-      "integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-4.0.0.tgz",
+      "integrity": "sha512-zymg51V1kZAXrzRNNS+da9nnDKdrOfkV/hoYYr0H174c5gIuT3mcwJFr27AhdTrP7wdEMtWFwlOFMyv99lQxTQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-routing": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
-      "integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-4.0.0.tgz",
+      "integrity": "sha512-NCo/S4E/MGi0LPC54pAQEKncWbV7Px5NtB4pWpq1RES2nLisS9SwA/7RnaESk9XpCFt4K788soQOKGzbTcQFdQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-strategies": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
-      "integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-4.0.0.tgz",
+      "integrity": "sha512-837Mk734rhNaqsD1uwWuDjoDddnkfaHWQMyCmBwUzsFb4UnRdInLH9SNIXDm6LgkDjKcoEdKAbp6336De60wLg==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-streams": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
-      "integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-4.0.0.tgz",
+      "integrity": "sha512-q9HE8r3BoLBZFAj5FWOhVnjcfmQ+lMaUxZS4FK259xeYDTF9wfo8cxN+inJyCeX6nq6jbWo7XWqGlXV88vaFfg==",
       "dev": true,
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "^4.0.0"
       }
     },
     "workbox-sw": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz",
-      "integrity": "sha512-IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-4.0.0.tgz",
+      "integrity": "sha512-lVSNtzOPbycn8pSuNtfroT+lXNBry8sUL1494cURIZE1MMFcxCZRv/718LoKIBeJnRYBKa/sXO2GXLzssHX15w==",
       "dev": true
+    },
+    "workbox-window": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-4.0.0.tgz",
+      "integrity": "sha512-gdLzP/L0vu5Gi3pdUYtVNmg0yE7OriEuYZBoLt8AYoILXh6cta9WsWHKQ0/pXfmEmZywr4Dfu0qkLLvc9VlZGQ==",
+      "dev": true,
+      "requires": {
+        "workbox-core": "^4.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp-usemin": "~0.3.28",
     "prettier": "~1.5.3",
     "require-dir": "^1.1.0",
-    "workbox-build": "^3.6.3"
+    "workbox-build": "4.0.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Raising PR for possible discussion in the future.

Upgrading Compare to use the latest version of [Workbox (4.0.0)](https://github.com/GoogleChrome/workbox/releases) that was released last week. Using the new `workbox-window` [module](https://developers.google.com/web/tools/workbox/modules/workbox-window) to register the service worker. This should simplify the process of service worker registration and give us more options in the future as this module evolves.

I have also minimised the use of pre-caching, this is now only used for the HTML file. Two additional caches are now created, one for application code (CSS and JS), and another for images. Doing so helps with debugging and also give a greater control over the caching strategies used and cache expiration times.

`cleanupOutdatedCaches` option enabled to automatically clear out old outdated 3.x.x caches.  