### PR TITLE
[BUGFIX] Comparing 2 har files with only one run fail

### DIFF
--- a/js/compare/load.js
+++ b/js/compare/load.js
@@ -201,7 +201,7 @@ function loadHARsFromConfig(config) {
         },
         har2: {
           har: har2,
-          run: reworkedConfig2.run || config.har2.run || 1,
+          run: reworkedConfig2.run || config.har2.run || 0,
           label: config.har2.label || 'HAR2'
         },
         comments: config.comments || undefined,


### PR DESCRIPTION
Hi,

I use  sitespeed.io to generate har files of my project. 

When I run analysis with only one run, I can't compare the two har files.

It looks like the script has a default value of 1 for the run in the second har file if nor reworkedConfig2.run neither config.har2.run is defined.

Maybe that was done to compare two runs of the same har file ? In this case, we should compare config.har1.url and config.har2.url and indeed set this value to 1.

However, I think 0 is a better default.

What's your opinion about this change ?

Thanks,