### PR TITLE
New BT 5 and sitespeed.io 9 produces other metrics that breaks compare

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
             </td>
           </tr>
           {{/if}} {{/if}}
-            {{#if cpuCategories1}} {{#if cpuCategories2}}
+            {{#if cpuCategories1.Painting}} {{#if cpuCategories2.Painting}}
             <tr>
               <td class="tabletext">CPU Painting:
               </td>


### PR DESCRIPTION
We can fix that later and now just make sure we show the CPU data for
older HARs.