### PR TITLE
Fixes #77, #70

### DIFF
--- a/js/compare/load.js
+++ b/js/compare/load.js
@@ -191,18 +191,22 @@ function loadHARsFromConfig(config) {
     }
     harPromise2 = loadJson(reworkedConfig2.url);
   }
+  let label1 = (new URL(reworkedConfig.url)).pathname;
+  let label2 = (new URL(reworkedConfig2.url)).pathname;
+  label1 = label1.replace(/.*\//, "");
+  label2 = label2.replace(/.*\//, "");
   Promise.all([harPromise, harPromise2])
     .then(([har1, har2]) =>
       generate({
         har1: {
           har: har1,
           run: reworkedConfig.run || config.har1.run || 0,
-          label: config.har1.label || 'HAR1'
+          label: config.har1.label || label1
         },
         har2: {
           har: har2,
           run: reworkedConfig2.run || config.har2.run || 0,
-          label: config.har2.label || 'HAR2'
+          label: config.har2.label || label2
         },
         comments: config.comments || undefined,
         title: config.title || 'Compare HAR files',

--- a/js/compare/load.js
+++ b/js/compare/load.js
@@ -191,10 +191,10 @@ function loadHARsFromConfig(config) {
     }
     harPromise2 = loadJson(reworkedConfig2.url);
   }
-  let label1 = (new URL(reworkedConfig.url)).pathname;
-  let label2 = (new URL(reworkedConfig2.url)).pathname;
-  label1 = label1.replace(/.*\//, "");
-  label2 = label2.replace(/.*\//, "");
+  let label1 = new URL(reworkedConfig.url).pathname;
+  let label2 = new URL(reworkedConfig2.url).pathname;
+  label1 = label1.replace(/.*\//, '');
+  label2 = label2.replace(/.*\//, '');
   Promise.all([harPromise, harPromise2])
     .then(([har1, har2]) =>
       generate({

--- a/js/compare/upload.js
+++ b/js/compare/upload.js
@@ -21,12 +21,12 @@ function createMainDropZone(id) {
             har1: {
               har: har1,
               run: 0,
-              label: 'HAR1'
+              label: files[0].name
             },
             har2: {
               har: har2,
               run: 0,
-              label: 'HAR2'
+              label: files[1].name
             }
           })
         )
@@ -46,7 +46,7 @@ function createMainDropZone(id) {
             har1: {
               har: har,
               run: 0,
-              label: 'HAR1'
+              label: files[0].name
             },
             har2: {
               har: har,


### PR DESCRIPTION
Use filename as HAR label for drag&drop.
Use last URI path component part as HAR label when using URLs. 