### PR TITLE
Derive filmstrip frames from VisualProgress change points

### DIFF
--- a/public/js/compare/filmstrip.js
+++ b/public/js/compare/filmstrip.js
@@ -31,26 +31,38 @@ function getFilmstripForPage(har, pageIndex) {
 
   // sitespeed.io path — derive the filmstrip URL base from the
   // screenshot URL (e.g. .../data/screenshots/1/afterPageCompleteCheck.jpg
-  // → .../data/filmstrip/1/ms_NNNNNN.jpg)
+  // → .../data/filmstrip/1/ms_NNNNNN.jpg) and read the actual frame
+  // timestamps from _visualMetrics.VisualProgress. Sitespeed.io emits
+  // exactly one filmstrip JPG per visual-progress *change point*, named
+  // after that ms — so the set of distinct-percentage timestamps in
+  // VisualProgress is the authoritative list of frames on disk.
   const meta = page._meta || {};
   const vm = page._visualMetrics;
-  if (meta.screenshot && vm) {
+  if (meta.screenshot && vm && vm.VisualProgress) {
     const m = meta.screenshot.match(/^(.+\/data)\/screenshots\/(\d+)\//);
     if (m) {
       const dataBase = m[1];
       const runId = m[2];
-      const firstVis = Number(vm.FirstVisualChange) || 0;
-      const lastVis = Number(vm.LastVisualChange) || 0;
+      const vp = vm.VisualProgress;
 
-      const times = [0];
-      // Sitespeed.io only emits frames where visual progress is
-      // changing — between First and Last Visual Change, at 100ms
-      // intervals, with the last frame at the exact LastVisualChange.
-      if (lastVis > 0) {
-        const startMs = Math.max(100, Math.ceil(firstVis / 100) * 100);
-        for (let t = startMs; t < lastVis; t += 100) times.push(t);
-        if (times[times.length - 1] !== lastVis) times.push(lastVis);
+      const sorted = Object.keys(vp)
+        .map(function (k) { return Number(k); })
+        .sort(function (a, b) { return a - b; });
+
+      const times = [];
+      let prevPct = null;
+      for (let i = 0; i < sorted.length; i++) {
+        const ms = sorted[i];
+        if (vp[ms] !== prevPct) {
+          times.push(ms);
+          prevPct = vp[ms];
+        }
       }
+
+      // VisualProgress should always start with a 0ms entry; if it
+      // didn't for some reason, anchor the strip so the first frame
+      // is the pre-load state.
+      if (!times.length || times[0] !== 0) times.unshift(0);
 
       return times.map(function (ms) {
         return {


### PR DESCRIPTION
  The earlier construction guessed at frames every 100 ms between
  FirstVisualChange and LastVisualChange. That works when visual
  progress is moving continuously (Sweden, Jannik), but runs with a
  flat stretch (MediaWiki — no visible change 1.2s → 1.7s) produce
  broken-image gaps because sitespeed.io only emits a JPG when visual
  progress actually changes, named ms_NNNNNN.jpg after that exact
  change-point timestamp.

  Read the frame timestamps straight from
  _visualMetrics.VisualProgress: every entry where the percentage
  changes from the previous one represents an emitted filmstrip frame.
  Verified across three real HARs — every constructed URL resolves to
  a real file on the origin.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com