### PR TITLE
Tighten the Render blocking section: labels, order, precision

### DIFF
--- a/public/js/compare/templates.js
+++ b/public/js/compare/templates.js
@@ -220,25 +220,14 @@ function pageXrayTemplate(d) {
 
   if (p1.renderBlocking && p2.renderBlocking) {
     html += section('Render blocking', 'blocking');
-    html += '<tr><td class="tabletext">Render blocking</td>' +
-            '<td>' + p1.renderBlocking.blocking + '</td>' +
-            '<td>' + p2.renderBlocking.blocking + '</td>' +
-            diffCell(p1.renderBlocking.blocking, p2.renderBlocking.blocking) + '</tr>';
-    html += '<tr><td class="tabletext">Potentially blocking</td>' +
-            '<td>' + p1.renderBlocking.potentiallyBlocking + '</td>' +
-            '<td>' + p2.renderBlocking.potentiallyBlocking + '</td>' +
-            diffCell(p1.renderBlocking.potentiallyBlocking, p2.renderBlocking.potentiallyBlocking) + '</tr>';
-    html += '<tr><td class="tabletext">In body parser blocking</td>' +
-            '<td>' + p1.renderBlocking.in_body_parser_blocking + '</td>' +
-            '<td>' + p2.renderBlocking.in_body_parser_blocking + '</td>' +
-            diffCell(p1.renderBlocking.in_body_parser_blocking, p2.renderBlocking.in_body_parser_blocking) + '</tr>';
 
     // Style recalculation before FCP / LCP. Sitespeed.io / browsertime
     // captures how many elements the browser re-styled and how long it
     // took on its way to each paint milestone — both are "lower is
-    // better", so the existing diff colouring applies. Guarded so a
-    // plain Chrome HAR (no recalculateStyle) doesn't render four empty
-    // rows.
+    // better", so the existing diff colouring applies. Rendered before
+    // the blocking-request counts so the eye sees the work first and
+    // the per-request counts as context. Guarded so a plain Chrome HAR
+    // (no recalculateStyle) doesn't render four empty rows.
     const rs1 = p1.renderBlocking.recalculateStyle;
     const rs2 = p2.renderBlocking.recalculateStyle;
     if (rs1 && rs2) {
@@ -249,18 +238,35 @@ function pageXrayTemplate(d) {
                diffCell(a, b, formatter) + '</tr>';
       }
       if (rs1.beforeFCP && rs2.beforeFCP) {
-        html += recalcRow('Style recalc elements (before FCP)',
+        html += recalcRow('Style recalc elements (FCP)',
                           rs1.beforeFCP.elements, rs2.beforeFCP.elements);
-        html += recalcRow('Style recalc duration (before FCP)',
+        html += recalcRow('Style recalc time (FCP)',
                           rs1.beforeFCP.durationInMillis, rs2.beforeFCP.durationInMillis, formatTime);
       }
       if (rs1.beforeLCP && rs2.beforeLCP) {
-        html += recalcRow('Style recalc elements (before LCP)',
+        html += recalcRow('Style recalc elements (LCP)',
                           rs1.beforeLCP.elements, rs2.beforeLCP.elements);
-        html += recalcRow('Style recalc duration (before LCP)',
+        html += recalcRow('Style recalc time (LCP)',
                           rs1.beforeLCP.durationInMillis, rs2.beforeLCP.durationInMillis, formatTime);
       }
     }
+
+    // The three counters below are *request* counts — how many
+    // resources fall into each render-blocking class. The "requests"
+    // suffix makes that explicit so the numbers aren't mistaken for
+    // milliseconds or sizes.
+    html += '<tr><td class="tabletext">Render blocking requests</td>' +
+            '<td>' + p1.renderBlocking.blocking + '</td>' +
+            '<td>' + p2.renderBlocking.blocking + '</td>' +
+            diffCell(p1.renderBlocking.blocking, p2.renderBlocking.blocking) + '</tr>';
+    html += '<tr><td class="tabletext">Potentially blocking requests</td>' +
+            '<td>' + p1.renderBlocking.potentiallyBlocking + '</td>' +
+            '<td>' + p2.renderBlocking.potentiallyBlocking + '</td>' +
+            diffCell(p1.renderBlocking.potentiallyBlocking, p2.renderBlocking.potentiallyBlocking) + '</tr>';
+    html += '<tr><td class="tabletext">In body parser blocking requests</td>' +
+            '<td>' + p1.renderBlocking.in_body_parser_blocking + '</td>' +
+            '<td>' + p2.renderBlocking.in_body_parser_blocking + '</td>' +
+            diffCell(p1.renderBlocking.in_body_parser_blocking, p2.renderBlocking.in_body_parser_blocking) + '</tr>';
   }
 
   if (p1.visualMetrics) {

--- a/public/js/compare/ux.js
+++ b/public/js/compare/ux.js
@@ -90,7 +90,11 @@ function formatURL(url) {
 function formatTime(ms) {
   if (ms !== undefined) {
     if (ms < 1000) {
-      return ms + ' ms';
+      // Round to whole milliseconds. Chrome's HAR timings are already
+      // integer ms for the page-level metrics (FCP/LCP/etc.), but
+      // browsertime's recalculateStyle field reports sub-ms precision
+      // ("17.099 ms") that's noise at this scale.
+      return Math.round(ms) + ' ms';
     } else {
       return Number(ms / 1000).toFixed(3) + ' s';
     }


### PR DESCRIPTION
  The blocking counters used to read like single-word measurements
  ("Render blocking" / "Potentially blocking"), making it ambiguous
  whether the number was milliseconds, bytes, or something else.
  Spell out that they're request counts. Move the style recalc rows
  above them so the actual work (elements touched / time spent)
  reads first and the per-class request totals follow as context.
  Tighten the recalc labels so the longest one fits the metric
  column on a single line. While we're here, round millisecond
  timings to whole ms — the only field that came through with
  sub-ms precision was the new recalc duration ("17.099 ms"),
  which is noise at this scale.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com